### PR TITLE
Feat(#137): 메인페이지 외 모든 페이지의 컨텐츠 레이아웃 중앙 정렬

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { usePathname } from "next/navigation";
-import Nav from "@/components/nav/Nav";
-import Footer from "@/components/footer/Footer";
+import { usePathname } from 'next/navigation';
+import Nav from '@/components/nav/Nav';
+import Footer from '@/components/footer/Footer';
 
 export default function ClientLayout({
   children,
@@ -10,13 +10,16 @@ export default function ClientLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const hideLayout = pathname === "/signin" || pathname === "/signup";
+  const signHideLayout = pathname === '/signin' || pathname === '/signup';
+  const mainHideLayout = pathname === '/';
 
   return (
     <>
-      {!hideLayout && <Nav />}
-      <div className={`${!hideLayout && "app"}`}>{children}</div>
-      {!hideLayout && <Footer />}
+      {!signHideLayout && <Nav />}
+      <div className={`${!signHideLayout && 'app'}`}>
+        <div className={`${!mainHideLayout && 'layout'}`}>{children}</div>
+      </div>
+      {!signHideLayout && <Footer />}
     </>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -161,5 +161,20 @@ body {
 
 .app {
   padding-top: 75px;
-  height: calc(100vh - 160px);
+  height: calc(100vh - calc(env(safe-area-inset-bottom)  + 160px));
+}
+
+.layout{
+  height:100%;
+  max-width: 1200px;
+    margin: 0 auto;
+
+    @media (max-width: 1248px) {
+      max-width: auto;
+      padding: 0 24px;
+    }
+
+    @media (max-width: 375px) {
+      padding: 0 20px;
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #137 

## 📝 작업 내용
메인페이지 외 모든 페이지의 컨텐츠 레이아웃 가운데 정렬

## 📸 결과물
<img width="1846" alt="스크린샷 2025-03-13 오후 3 29 22" src="https://github.com/user-attachments/assets/f99710a9-9d16-4eca-97b8-e33fd3940a5c" />

## 👩‍💻 공유 포인트 및 논의 사항
메인페이지는 승환님과 조율 완료