### PR TITLE
feat(#33): 카테고리별 체험목록 정렬

### DIFF
--- a/src/app/landingComponents/ActivitiesList.module.css
+++ b/src/app/landingComponents/ActivitiesList.module.css
@@ -1,6 +1,6 @@
 .activitiesContainer {
   max-width: 1200px;
-  margin: 30px auto;
+  margin: 0 auto 30px;
 
   @media (max-width: 1248px) { 
     max-width: auto; 

--- a/src/app/landingComponents/Category.module.css
+++ b/src/app/landingComponents/Category.module.css
@@ -1,0 +1,56 @@
+.categoryContainer {
+  max-width: 1200px;
+  margin: 0 auto; 
+  display: flex;
+  justify-content: space-between;
+
+  @media (max-width: 1248px) { 
+    max-width: auto; 
+    padding: 0 24px; 
+  } 
+  @media (max-width: 375px) { 
+    padding: 0 16px; 
+  }
+}
+
+.category {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-x: auto;
+  white-space: nowrap; 
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none; /* Firefox */
+}
+.category::-webkit-scrollbar {
+  display: none; /* Chrome, Safari */
+}
+
+.category .item {
+  background-color: var(--white);
+  color: var(--green);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 26px;
+  text-align: center;
+  width: 130px;
+  display: inline-block;
+  border: 1px solid var(--green);
+  border-radius: 15px;
+  padding: 11px 14px 8px 15px;
+  margin-right: 10px;
+  cursor: pointer;
+
+  @media (max-width: 768px) {
+    font-size: 14px;
+    line-height: 20px;
+    width: 110px;
+    margin-right: 8px;
+  }
+  @media (max-width: 450px) {
+    font-size: 12px;
+    width: 90px;
+    padding: 9px 9px 6px 12px;
+    margin-right: 4px;
+  }
+}

--- a/src/app/landingComponents/Category.module.css
+++ b/src/app/landingComponents/Category.module.css
@@ -2,7 +2,7 @@
   max-width: 1200px;
   margin: 0 auto; 
   display: flex;
-  justify-content: space-between;
+  position: relative;
 
   @media (max-width: 1248px) { 
     max-width: auto; 
@@ -14,6 +14,7 @@
 }
 
 .category {
+  flex-grow: 1;
   list-style: none;
   padding: 0;
   margin: 0;
@@ -21,14 +22,13 @@
   white-space: nowrap; 
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none; /* Firefox */
+  position: relative;
 }
 .category::-webkit-scrollbar {
   display: none; /* Chrome, Safari */
 }
 
 .category .item {
-  background-color: var(--white);
-  color: var(--green);
   font-size: 16px;
   font-weight: 500;
   line-height: 26px;
@@ -53,4 +53,12 @@
     padding: 9px 9px 6px 12px;
     margin-right: 4px;
   }
+}
+.category .selected {
+  background-color: var(--green);
+  color: var(--white);
+}
+.category .deselected {
+  background-color: var(--white);
+  color: var(--green);
 }

--- a/src/app/landingComponents/Category.tsx
+++ b/src/app/landingComponents/Category.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import Dropdown from '@/components/Dropdown';
+import styles from './Category.module.css';
+
+// 카테고리 및 정렬 옵션을 관리하는 컴포넌트
+interface CategoryProps {
+  categories: string[];
+  selectedCategory: string | null;
+  selectedSort: string | null;
+  onCategoryClick: (category: string) => void;
+  onSortChange: (value: string) => void;
+}
+
+const Category: React.FC<CategoryProps> = ({
+  categories,
+  selectedCategory,
+  selectedSort,
+  onCategoryClick,
+  onSortChange,
+}) => {
+  const sortOptions = [
+    { value: 'latest', label: '최신순' },
+    { value: 'most_reviewed', label: '리뷰많은순' },
+    { value: 'price_asc', label: '낮은가격순' },
+    { value: 'price_desc', label: '높은가격순' },
+  ];
+
+  return (
+    <div className={styles.categoryContainer}>
+      <ul className={styles.category}>
+        {categories.map((category) => (
+          <li
+            key={category}
+            className={styles.item}
+            onClick={() => onCategoryClick(category)}
+            style={{
+              color:
+                selectedCategory === category ? 'var(--white)' : 'var(--green)',
+              backgroundColor:
+                selectedCategory === category ? 'var(--green)' : 'var(--white)',
+              cursor: 'pointer',
+            }}
+          >
+            {category}
+          </li>
+        ))}
+      </ul>
+      <Dropdown
+        options={sortOptions}
+        selectedValue={selectedSort}
+        onChange={onSortChange}
+      />
+    </div>
+  );
+};
+
+export default Category;

--- a/src/app/landingComponents/Category.tsx
+++ b/src/app/landingComponents/Category.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import Dropdown from '@/components/Dropdown';
 import styles from './Category.module.css';
 
-// 카테고리 및 정렬 옵션을 관리하는 컴포넌트
 interface CategoryProps {
   categories: string[];
   selectedCategory: string | null;
@@ -13,13 +12,13 @@ interface CategoryProps {
   onSortChange: (value: string) => void;
 }
 
-const Category: React.FC<CategoryProps> = ({
+export default function Category({
   categories,
   selectedCategory,
   selectedSort,
   onCategoryClick,
   onSortChange,
-}) => {
+}: CategoryProps) {
   const sortOptions = [
     { value: 'latest', label: '최신순' },
     { value: 'most_reviewed', label: '리뷰많은순' },
@@ -33,15 +32,12 @@ const Category: React.FC<CategoryProps> = ({
         {categories.map((category) => (
           <li
             key={category}
-            className={styles.item}
+            className={`${styles.item} ${
+              selectedCategory === category
+                ? styles.selected
+                : styles.deselected
+            }`}
             onClick={() => onCategoryClick(category)}
-            style={{
-              color:
-                selectedCategory === category ? 'var(--white)' : 'var(--green)',
-              backgroundColor:
-                selectedCategory === category ? 'var(--green)' : 'var(--white)',
-              cursor: 'pointer',
-            }}
           >
             {category}
           </li>
@@ -54,6 +50,4 @@ const Category: React.FC<CategoryProps> = ({
       />
     </div>
   );
-};
-
-export default Category;
+}

--- a/src/app/landingComponents/LandingPage.module.css
+++ b/src/app/landingComponents/LandingPage.module.css
@@ -60,64 +60,6 @@
   }
 }
 
-/* 카테고리 영역 */
-.categoryContainer {
-  max-width: 1200px;
-  margin: 0 auto; 
-  display: flex;
-  justify-content: space-between;
-
-  @media (max-width: 1248px) { 
-    max-width: auto; 
-    padding: 0 24px; 
-  } 
-  @media (max-width: 375px) { 
-    padding: 0 16px; 
-  }
-}
-
-.category {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  overflow-x: auto;
-  white-space: nowrap; 
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none; /* Firefox */
-}
-.category::-webkit-scrollbar {
-  display: none; /* Chrome, Safari */
-}
-
-.category .item {
-  background-color: var(--white);
-  color: var(--green);
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 26px;
-  text-align: center;
-  width: 130px;
-  display: inline-block;
-  border: 1px solid var(--green);
-  border-radius: 15px;
-  padding: 11px 14px 8px 15px;
-  margin-right: 10px;
-  cursor: pointer;
-
-  @media (max-width: 768px) {
-    font-size: 14px;
-    line-height: 20px;
-    width: 110px;
-    margin-right: 8px;
-  }
-  @media (max-width: 450px) {
-    font-size: 12px;
-    width: 90px;
-    padding: 9px 9px 6px 12px;
-    margin-right: 4px;
-  }
-}
-
 .title {
   font-size: 30px;
   font-weight: 700;

--- a/src/app/landingComponents/LandingPage.module.css
+++ b/src/app/landingComponents/LandingPage.module.css
@@ -117,3 +117,27 @@
     margin-right: 4px;
   }
 }
+
+.title {
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 32px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 30px auto 25px;
+
+  @media (max-width: 1248px) { 
+    max-width: auto; 
+    padding: 0 24px;
+  } 
+  @media (max-width: 768px) {
+    font-size: 28px;
+  }
+  @media (max-width: 450px) {
+    font-size: 20px;
+    margin: 15px auto 10px;
+  }
+  @media (max-width: 375px) { 
+    padding: 0 16px; 
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,15 +7,24 @@ import PopularActivities from './landingComponents/PopulorActivities';
 import ActivitiesList from './landingComponents/ActivitiesList';
 import Dropdown from '@/components/Dropdown';
 import Pagination from './landingComponents/Pagination';
-// import Footer from '@/components/footer/Footer';
 import styles from './landingComponents/LandingPage.module.css';
+
+// params 타입 정의
+interface ActivitiesParams {
+  method: string;
+  page: number;
+  size: number;
+  sort: string | null;
+  category?: string | null;
+}
 
 export default function Home() {
   const [selectedSort, setSelectedSort] = useState<string | null>('latest');
-  const [activities, setActivities] = useState<ActivitiesArray>([]);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [activities, setActivities] = useState<ActivitiesArray>([]); // ActivitiesArray 타입을 사용
   const [popularActivities, setPopularActivities] = useState<ActivitiesArray>(
     [],
-  );
+  ); // ActivitiesArray 타입을 사용
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [size, setSize] = useState(8);
@@ -27,6 +36,15 @@ export default function Home() {
     { value: 'most_reviewed', label: '리뷰많은순' },
     { value: 'price_asc', label: '낮은가격순' },
     { value: 'price_desc', label: '높은가격순' },
+  ];
+
+  const categories = [
+    '문화 · 예술',
+    '식음료',
+    '스포츠',
+    '투어',
+    '관광',
+    '웰빙',
   ];
 
   useEffect(() => {
@@ -53,16 +71,20 @@ export default function Home() {
     const fetchActivities = async () => {
       setIsLoading(true);
       try {
-        const response = await axios.get('/activities', {
-          params: {
-            method: 'offset',
-            page: currentPage,
-            size: size,
-            sort: selectedSort,
-          },
-        });
+        const params: ActivitiesParams = {
+          method: 'offset',
+          page: currentPage,
+          size: size,
+          sort: selectedSort,
+        };
 
-        setActivities(response.data.activities);
+        if (selectedCategory) {
+          params['category'] = selectedCategory; // 카테고리 필터링 추가
+        }
+
+        const response = await axios.get('/activities', { params });
+
+        setActivities(response.data.activities); // ActivitiesArray 타입으로 받음
         setTotalPages(Math.ceil(response.data.totalCount / size)); // 전체 페이지 수 계산
       } catch (error) {
         console.error('데이터 가져오기 실패:', error);
@@ -73,7 +95,7 @@ export default function Home() {
     };
 
     fetchActivities();
-  }, [size, currentPage, selectedSort]);
+  }, [size, currentPage, selectedSort, selectedCategory]);
 
   // 인기체험 API호출
   useEffect(() => {
@@ -83,7 +105,7 @@ export default function Home() {
           params: { method: 'offset', page: 1, size: 9 },
         });
 
-        setPopularActivities(response.data.activities);
+        setPopularActivities(response.data.activities); // ActivitiesArray 타입으로 받음
       } catch (error) {
         console.error('인기 체험 데이터 가져오기 실패:', error);
       }
@@ -95,6 +117,15 @@ export default function Home() {
   // 페이지 변경
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
+  };
+
+  // 카테고리 클릭 시 필터링
+  const handleCategoryClick = (category: string) => {
+    if (selectedCategory === category) {
+      setSelectedCategory(null); // 같은 카테고리 클릭 시 필터링 해제
+    } else {
+      setSelectedCategory(category); // 카테고리 선택 시 필터링
+    }
   };
 
   return (
@@ -113,12 +144,26 @@ export default function Home() {
       {/* 카테고리 영역 */}
       <div className={styles.categoryContainer}>
         <ul className={styles.category}>
-          <li className={styles.item}>문화•예술</li>
-          <li className={styles.item}>식음료</li>
-          <li className={styles.item}>스포츠</li>
-          <li className={styles.item}>투어</li>
-          <li className={styles.item}>관광</li>
-          <li className={styles.item}>웰빙</li>
+          {categories.map((category) => (
+            <li
+              key={category}
+              className={styles.item}
+              onClick={() => handleCategoryClick(category)}
+              style={{
+                color:
+                  selectedCategory === category
+                    ? 'var(--white)'
+                    : 'var(--green)',
+                backgroundColor:
+                  selectedCategory === category
+                    ? 'var(--green)'
+                    : 'var(--white)',
+                cursor: 'pointer',
+              }}
+            >
+              {category}
+            </li>
+          ))}
         </ul>
         <Dropdown
           options={sortOptions}
@@ -126,6 +171,11 @@ export default function Home() {
           onChange={setSelectedSort}
         />
       </div>
+      {/* 선택된 카테고리에 따른 타이틀 변경 */}
+      <h2 className={styles.title}>
+        {selectedCategory ? selectedCategory : '🛼 모든 체험'}
+      </h2>
+
       {/* 체험 리스트 */}
       <ActivitiesList
         activities={activities}
@@ -138,8 +188,6 @@ export default function Home() {
         totalPages={totalPages}
         setPage={handlePageChange}
       />
-
-      {/* <Footer /> */}
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,8 @@ import axios from '@/lib/api';
 import { ActivitiesArray } from '@/lib/types';
 import PopularActivities from './landingComponents/PopulorActivities';
 import ActivitiesList from './landingComponents/ActivitiesList';
-import Dropdown from '@/components/Dropdown';
 import Pagination from './landingComponents/Pagination';
+import Category from './landingComponents/Category';
 import styles from './landingComponents/LandingPage.module.css';
 
 // params 타입 정의
@@ -19,24 +19,17 @@ interface ActivitiesParams {
 }
 
 export default function Home() {
-  const [selectedSort, setSelectedSort] = useState<string | null>('latest');
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [activities, setActivities] = useState<ActivitiesArray>([]); // ActivitiesArray 타입을 사용
-  const [popularActivities, setPopularActivities] = useState<ActivitiesArray>(
-    [],
-  ); // ActivitiesArray 타입을 사용
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [size, setSize] = useState(8);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-
-  const sortOptions = [
-    { value: 'latest', label: '최신순' },
-    { value: 'most_reviewed', label: '리뷰많은순' },
-    { value: 'price_asc', label: '낮은가격순' },
-    { value: 'price_desc', label: '높은가격순' },
-  ];
+  const [activities, setActivities] = useState<ActivitiesArray>([]);
+  const [popularActivities, setPopularActivities] = useState<ActivitiesArray>(
+    [],
+  );
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedSort, setSelectedSort] = useState<string | null>('latest');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const categories = [
     '문화 · 예술',
@@ -84,7 +77,7 @@ export default function Home() {
 
         const response = await axios.get('/activities', { params });
 
-        setActivities(response.data.activities); // ActivitiesArray 타입으로 받음
+        setActivities(response.data.activities);
         setTotalPages(Math.ceil(response.data.totalCount / size)); // 전체 페이지 수 계산
       } catch (error) {
         console.error('데이터 가져오기 실패:', error);
@@ -105,7 +98,7 @@ export default function Home() {
           params: { method: 'offset', page: 1, size: 9 },
         });
 
-        setPopularActivities(response.data.activities); // ActivitiesArray 타입으로 받음
+        setPopularActivities(response.data.activities);
       } catch (error) {
         console.error('인기 체험 데이터 가져오기 실패:', error);
       }
@@ -139,39 +132,16 @@ export default function Home() {
           <p className={styles.text2}>1월의 인기체험 BEST</p>
         </div>
       </div>
-      {/* 인기 체험 */}
+      {/* 인기체험 리스트 */}
       <PopularActivities activities={popularActivities} />
-      {/* 카테고리 영역 */}
-      <div className={styles.categoryContainer}>
-        <ul className={styles.category}>
-          {categories.map((category) => (
-            <li
-              key={category}
-              className={styles.item}
-              onClick={() => handleCategoryClick(category)}
-              style={{
-                color:
-                  selectedCategory === category
-                    ? 'var(--white)'
-                    : 'var(--green)',
-                backgroundColor:
-                  selectedCategory === category
-                    ? 'var(--green)'
-                    : 'var(--white)',
-                cursor: 'pointer',
-              }}
-            >
-              {category}
-            </li>
-          ))}
-        </ul>
-        <Dropdown
-          options={sortOptions}
-          selectedValue={selectedSort}
-          onChange={setSelectedSort}
-        />
-      </div>
-      {/* 선택된 카테고리에 따른 타이틀 변경 */}
+      {/* 카테고리 */}
+      <Category
+        categories={categories}
+        selectedCategory={selectedCategory}
+        selectedSort={selectedSort}
+        onCategoryClick={handleCategoryClick}
+        onSortChange={setSelectedSort}
+      />
       <h2 className={styles.title}>
         {selectedCategory ? selectedCategory : '🛼 모든 체험'}
       </h2>
@@ -182,7 +152,6 @@ export default function Home() {
         isLoading={isLoading}
         error={error}
       />
-      {/* 페이지네이션 */}
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}


### PR DESCRIPTION
## #️⃣ 이슈

- #33 

## 📝 작업 내용
처음 랜더링시 모든체험 보여줌
카테고리 별로 클릭시 그에 맞는 목록 데이터 가져옴

## 📸 결과물
<img width="1440" alt="스크린샷 2025-03-24 오전 2 26 08" src="https://github.com/user-attachments/assets/0e267c2a-7015-46db-8f42-4171795d9801" />

## 👩‍💻 공유 포인트 및 논의 사항
