### PR TITLE
feat(#225): 검색창 포커스 시 placeholder 위로 이동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@svgr/webpack": "^8.1.0",
-        "@tanstack/react-query": "^5.68.0",
+        "@tanstack/react-query": "^5.69.0",
         "@tanstack/react-query-devtools": "^5.68.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.13",
@@ -7583,6 +7583,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
@@ -10392,6 +10401,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/form-data": {
@@ -17254,12 +17273,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
-    "@tanstack/react-query": "^5.68.0",
+    "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.68.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.13",

--- a/src/app/landingComponents/PopulorActivities.tsx
+++ b/src/app/landingComponents/PopulorActivities.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import Image from 'next/image';
 import { FaStar } from 'react-icons/fa';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -15,7 +15,6 @@ interface Props {
 export default function PopularActivities({ activities }: Props) {
   const [index, setIndex] = useState(0);
   const [itemsSize, setItemsSize] = useState(3);
-  const [sortedActivities, setSortedActivities] = useState<ActivitiesArray>([]);
   const [imageSrcMap, setImageSrcMap] = useState<{ [key: number]: string }>({});
 
   // 화면 사이즈 별 데이터 업로드 갯수
@@ -35,23 +34,22 @@ export default function PopularActivities({ activities }: Props) {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
+  // 인기 체험 목록 평점 내림차순 정렬 (useMemo 사용)
+  const sortedActivities = useMemo(() => {
+    return [...activities].sort((a, b) => {
+      const ratingA = a.rating ?? 0;
+      const ratingB = b.rating ?? 0;
+      return ratingB - ratingA; // 평점 내림차순
+    });
+  }, [activities]);
+
   // 인기목록 자동 스크롤
   useEffect(() => {
     const interval = setInterval(() => {
       setIndex((prev) => (prev + 1) % sortedActivities.length);
     }, 4000);
     return () => clearInterval(interval);
-  }, [sortedActivities.length]);
-
-  // 인기 체험 목록 평점 내림차순 정렬
-  useEffect(() => {
-    const sorted = [...activities].sort((a, b) => {
-      const ratingA = a.rating ?? 0;
-      const ratingB = b.rating ?? 0;
-      return ratingB - ratingA; // 평점 내림차순
-    });
-    setSortedActivities(sorted);
-  }, [activities]);
+  }, [sortedActivities]); // sortedActivities 의존성 추가
 
   // 이미지 로드 실패 시 기본 이미지로 변경
   const handleImageError = (id: number) => {
@@ -65,6 +63,7 @@ export default function PopularActivities({ activities }: Props) {
   const nextSlide = () => {
     setIndex((prev) => (prev + 1) % sortedActivities.length);
   };
+
   // 이전으로 돌아감
   const prevSlide = () => {
     setIndex(

--- a/src/app/landingComponents/PopulorActivities.tsx
+++ b/src/app/landingComponents/PopulorActivities.tsx
@@ -34,7 +34,7 @@ export default function PopularActivities({ activities }: Props) {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  // 인기 체험 목록 평점 내림차순 정렬 (useMemo 사용)
+  // 인기 체험 목록 평점 내림차순 정렬
   const sortedActivities = useMemo(() => {
     return [...activities].sort((a, b) => {
       const ratingA = a.rating ?? 0;
@@ -120,7 +120,7 @@ export default function PopularActivities({ activities }: Props) {
                   <div className={styles.activitiesRating}>
                     <FaStar color='var(--yellow)' size={14} />
                     <p>
-                      {activity.rating ?? 0} {/* 기본값 0 */}
+                      {activity.rating ?? 0}
                       <span> ({activity.reviewCount})</span>
                     </p>
                   </div>

--- a/src/app/landingComponents/Search.module.css
+++ b/src/app/landingComponents/Search.module.css
@@ -50,6 +50,7 @@
 
 /* 검색값 입력 필드 */
 .inputContainer {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 16px;
@@ -58,41 +59,69 @@
     gap: 8px;
   }
 }
+
 .searchInput {
   flex: 1;
-  color: var(--nomad-dark);
+  color: var(--gray-dark);
   font-size: 16px;
   font-weight: 400;
-  padding: 12px 16px 10px;
+  padding: 14px 16px 8px;
   border: 1px solid var(--gray-light);
   border-radius: 4px;
   outline: none;
+  background: transparent;
 
   @media (max-width: 550px) {
     font-size: 14px;
   }
 }
+.searchInput:focus {
+  border-color: var(--gray-dark);
+}
+/* 기존 placeholder 숨김 */
 .searchInput::placeholder {
+  color: transparent;
+}
+
+/* 플로팅 라벨 */
+.placeholder {
+  position: absolute;
+  left: 16px;
+  top: 50%;
   color: var(--gray-soft);
   font-size: 16px;
   font-weight: 400;
+  transform: translateY(-50%);
+  transition: all 0.2s ease-in-out;
+  pointer-events: none;
 
   @media (max-width: 550px) {
+    left: 10px;
     font-size: 14px;
   }
+}
+/* input에 포커스 또는 값이 있을 때 위로 이동 */
+.inputContainer.focused .placeholder,
+.searchInput:not(:placeholder-shown) + .placeholder {
+  background-color: var(--white);
+  font-size: 12px;
+  padding: 0 8px;
+  top: 2px;
 }
 
 /* 검색 버튼 */
 .searchBtn {
   min-width: 70px;
+  height: 43.5px;
   padding: 8px 38px 6px;
-
+  
   @media (max-width: 660px) {
     padding: 8px 20px 6px;
   }
   @media (max-width: 550px) {
     font-size: 14px;
     font-weight: 500;
+    height: 40.5px;
     padding: 8px 5px 6px;
   }
 }

--- a/src/app/landingComponents/Search.tsx
+++ b/src/app/landingComponents/Search.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import React from 'react';
+import React, { useState } from 'react';
 import CustomButton from '@/components/CustomButton';
 import styles from './Search.module.css';
 
@@ -17,18 +15,27 @@ export default function Search({
   onSearch,
   onKeyPress,
 }: SearchProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
   return (
     <div className={styles.container}>
       <div className={styles.searchContainer}>
         <h1>무엇을 체험하고 싶으신가요?</h1>
-        <div className={styles.inputContainer}>
+        <div
+          className={`${styles.inputContainer} ${
+            isFocused || inputValue ? styles.focused : ''
+          }`}
+        >
+          <label className={styles.placeholder}>내가 원하는 체험은</label>
           <input
             type='text'
             className={styles.searchInput}
             value={inputValue}
             onChange={onInputChange}
             onKeyDown={onKeyPress}
-            placeholder='내가 원하는 체험은 ?'
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder=''
           />
           <CustomButton
             onClick={onSearch}


### PR DESCRIPTION
## #️⃣ 이슈

- #225 

## 📝 작업 내용

- 인기 체험 리스트의 평점 내림차순 useEffect -> useMemo 로 변경(PopulorActivites.tsx)
- 검색창 포커스 시 placeholder 테두리에 고정 (Search.tsx, Search.module.css)
 
## 📸 결과물
- 포커스 아웃
<img width="1248" alt="스크린샷 2025-03-25 오후 5 01 02" src="https://github.com/user-attachments/assets/9ccde45e-8b71-4b5f-8822-a21db9a6501a" />
- 포커스 인
<img width="1248" alt="스크린샷 2025-03-25 오후 4 53 54" src="https://github.com/user-attachments/assets/385e51ca-97d9-46ba-982a-660ba70f232a" />
- 검색어 입력 상태
<img width="1248" alt="스크린샷 2025-03-25 오후 5 00 22" src="https://github.com/user-attachments/assets/b7d1bf17-e172-451e-8152-7db8e84e94d0" />


## 👩‍💻 공유 포인트 및 논의 사항
테두리, 글자 두께 및 색상 각자 의견을 토대로 수정 가능