### PR TITLE
Fix(#이슈번호X): Features 브랜치 기준 footer 일괄 적용으로 변경

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { usePathname } from 'next/navigation';
 import Nav from '@/components/nav/Nav';
+import Footer from '@/components/footer/Footer';
 
 const queryClient = new QueryClient();
 
@@ -23,6 +24,7 @@ export default function ClientLayout({
       <div className={`${!signHideLayout && 'app'}`}>
         <div className={`${!mainHideLayout && 'layout'}`}>{children}</div>
       </div>
+      {!signHideLayout && <Footer />}
       <ReactQueryDevtools initialIsOpen={false} /> {/* React Query DevTools */}
     </QueryClientProvider>
   );

--- a/src/app/landingComponents/LandingPage.module.css
+++ b/src/app/landingComponents/LandingPage.module.css
@@ -1,3 +1,7 @@
+.layout{
+  padding-bottom:160px;
+}
+
 .imgContainer {
   position: relative;
   width: 100%;

--- a/src/app/myreservation/page.tsx
+++ b/src/app/myreservation/page.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import Empty from '@/components/empty/Empty';
-import Footer from '@/components/footer/Footer';
 import ReservationList from './components/ReservationList';
 import useReservation from '@/hooks/query/useReservation';
 import styles from './style.module.css';
@@ -74,7 +73,6 @@ export default function MyReservation() {
           </>
         )}
       </div>
-      <Footer />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import PopularActivities from './landingComponents/PopulorActivities';
 import ActivitiesList from './landingComponents/ActivitiesList';
 import Pagination from './landingComponents/Pagination';
 import Category from './landingComponents/Category';
-// import Footer from '@/components/footer/Footer';
 import styles from './landingComponents/LandingPage.module.css';
 
 export default function Home() {
@@ -138,7 +137,7 @@ export default function Home() {
   const totalPages = Math.ceil(totalCount / size);
 
   return (
-    <>
+    <div className={styles.layout}>
       <div className={styles.imgContainer}>
         <div className={styles.textContainer}>
           <p className={styles.text1}>
@@ -194,8 +193,6 @@ export default function Home() {
         totalPages={totalPages}
         setPage={handlePageChange}
       />
-
-      {/* <Footer /> */}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #이슈번호X

## 📝 작업 내용
- 로그인/회원가입 제외 나머지 페이지들에 footer 일괄 적용

## 📸 결과물
<img width="2033" alt="스크린샷 2025-04-04 오후 1 52 25" src="https://github.com/user-attachments/assets/83ec76b1-85b6-46d9-b423-a36f928af9c0" />

## 👩‍💻 공유 포인트 및 논의 사항
- (landing) page.tsx > Fragments를 div로 변경 후 클래스로 다른 페이지들(초기 세팅)과 동일하게 css 값 추가 했습니다.
