### PR TITLE
Refactor(#304): 네비게이션 - 유저 데이터 API 불러오기 > useQuery로 변경

### DIFF
--- a/src/components/empty/empty.module.css
+++ b/src/components/empty/empty.module.css
@@ -22,6 +22,8 @@ components > empty > empty.module.css
     margin: 120px auto 15px;
     width: calc(100vw * (240 / 1200));
     height: calc(100vw * (240 / 1200));
+    max-width:240px;
+    max-height:240px;
     min-width: 200px;
     min-height: 200px;
   }

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -7,7 +7,7 @@ import styles from './nav.module.css';
 import NavProfileCard from './NavProfileCard';
 import NotificationModal from '../notification/NotificationModal';
 import useClickOutside from '@/utils/useClickOutside';
-import { useAuthStore } from '@/stores/useAuthStore';
+import useUser from '@/hooks/query/useUser';
 
 export default function Nav() {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -18,7 +18,7 @@ export default function Nav() {
   const modalRef = useRef<HTMLDivElement>(null);
   const profileRef = useRef<HTMLDivElement>(null);
 
-  const { user } = useAuthStore();
+  const { data: user } = useUser();
 
   const handleImageError = (id: string) => {
     setImageSrcMap((prev) => ({ ...prev, [id]: '/images/no_profileImg.svg' }));

--- a/src/components/nav/NavProfileCard.tsx
+++ b/src/components/nav/NavProfileCard.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from './nav.module.css';
-import { useAuthStore } from '@/stores/useAuthStore';
+import useUser from '@/hooks/query/useUser';
 
 interface Props {
   imageSrcMap: Record<string, string>;
@@ -14,7 +14,7 @@ export default function NavProfileCard({
   imageSrcMap,
   handleImageError,
 }: Props) {
-  const { user } = useAuthStore();
+  const { data:user } = useUser();
 
   return (
     <div className={styles.profileCardContainer}>

--- a/src/hooks/query/useUser.tsx
+++ b/src/hooks/query/useUser.tsx
@@ -3,7 +3,7 @@ import instance from '@/lib/api';
 import { User } from '@/lib/types';
 
 // API 요청 함수
-const fetchUser = async (): Promise<User[]> => {
+const fetchUser = async (): Promise<User> => {
   try {
     const response = await instance.get('/users/me');
     //console.log('API 응답 데이터:', response.data); // 응답 데이터 확인
@@ -16,7 +16,7 @@ const fetchUser = async (): Promise<User[]> => {
 
 // React Query 훅
 const useUser = () => {
-  return useQuery<User[]>({
+  return useQuery<User>({
     queryKey: ['user'],
     queryFn: fetchUser,
   });


### PR DESCRIPTION
## #️⃣ 이슈

- close #304 

## 📝 작업 내용
- 빈 페이지일 때의 Empty.tsx에서 내부 이미지가 무제한으로 커지는 버그를 발견하여 CSS 한 줄 추가 하였습니다.
- 유저 데이터를 받아오는 루트를 useAuthStore > useQuery 로 변경 하였습니다.

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
- 내 정보 수정 시 네비게이션의 내 정보가 즉시 변경되지 않는 버그 수정
