### PR TITLE
Feat(#112): GNB컴포넌트에 로그아웃기능 구현

### DIFF
--- a/src/app/(auth)/oauth/kakao/signin-callback/page.tsx
+++ b/src/app/(auth)/oauth/kakao/signin-callback/page.tsx
@@ -1,27 +1,35 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useKakaoSignInMutation } from '@/hooks/useAuth';
-import { toast } from 'react-hot-toast';
 
 export default function KakaoSignInCallbackPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const code = searchParams.get('code');
   const kakaoSignIn = useKakaoSignInMutation();
+  const [isProcessed, setIsProcessed] = useState(false);
+  const [code, setCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    const paramsCode = searchParams.get('code');
+    if (paramsCode && !code) {
+      setCode(paramsCode);
+    }
+  }, [searchParams, code]);
 
   useEffect(() => {
     if (!code) {
-      toast.error('인가 코드가 없습니다.');
       setTimeout(() => {
         router.push('/signin');
       }, 1500);
       return;
     }
+    if (isProcessed) return;
+    setIsProcessed(true);
 
     kakaoSignIn.mutate(code);
-  }, [code, router, kakaoSignIn]);
+  }, [code, router, kakaoSignIn, isProcessed]);
 
   return (
     <div style={{ textAlign: 'center', marginTop: '50px' }}>

--- a/src/components/nav/NavProfileCard.tsx
+++ b/src/components/nav/NavProfileCard.tsx
@@ -14,7 +14,7 @@ export default function NavProfileCard({
   imageSrcMap,
   handleImageError,
 }: Props) {
-  const { user } = useAuthStore();
+  const { user, logout } = useAuthStore();
 
   return (
     <div className={styles.profileCardContainer}>
@@ -81,7 +81,9 @@ export default function NavProfileCard({
             예약 현황
           </Link>
         </li>
-        <li className={styles.logoutBtn}>로그아웃</li>
+        <li className={styles.logoutBtn} onClick={() => logout()}>
+          로그아웃
+        </li>
       </ul>
     </div>
   );

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -29,6 +29,7 @@ function useSignInMutation() {
       router.push('/');
     },
     onError: (error: unknown) => {
+      console.error('카카오 로그인 오류:', error); // ⭐️ 로그 찍기
       if (error instanceof Error) {
         toast.error(error.message);
       } else {
@@ -65,15 +66,22 @@ function useKakaoSignInMutation() {
 
   return useMutation({
     mutationFn: (code: string) => kakaoSignIn(code),
-    onSuccess: (response: SignInResponse) => {
+    onSuccess: (response) => {
+      if (!response || !response.user) {
+        toast.error('로그인 응답이 올바르지 않습니다.');
+        return;
+      }
+
       setAuth(response.user);
       Cookies.set('accessToken', response.accessToken);
       Cookies.set('refreshToken', response.refreshToken);
-      toast.success('로그인 성공!');
+      Cookies.set('kakaoLogin', 'true');
+      toast.success('로그인 성공!', { id: 'loginSuccess' });
       router.push('/');
     },
     onError: (error: unknown) => {
       if (error instanceof Error) {
+        console.error(error);
         toast.error(error.message);
       } else {
         toast.error('알 수 없는 오류가 발생했습니다.');

--- a/src/lib/auth-api.ts
+++ b/src/lib/auth-api.ts
@@ -61,8 +61,7 @@ export async function kakaoSignUp(code: string, nickname: string) {
 // 카카오 간편 로그인 api
 export async function kakaoSignIn(code: string) {
   if (!code) {
-    console.error('인가 코드가 없습니다.');
-    return;
+    throw new Error('인가 코드가 없습니다.');
   }
   try {
     const response = await instance.post('/oauth/sign-in/kakao', {

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -32,7 +32,9 @@ export const useAuthStore = create<AuthState>()(
         const clientId = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
         const logoutRedirectUri = `http://localhost:3000/signin`;
 
-        if (clientId) {
+        const isKakaoLogin = Cookies.get('kakaoLogin');
+        if (isKakaoLogin) {
+          Cookies.remove('kakaoLogin');
           window.location.href = `https://kauth.kakao.com/oauth/logout?client_id=${clientId}&logout_redirect_uri=${encodeURIComponent(
             logoutRedirectUri,
           )}`;


### PR DESCRIPTION
## #️⃣ 이슈

- close #112 

## 📝 작업 내용
 - 로그아웃 기능을 GNB 프로필카드에 추가했습니다.

## 📸 결과물
 
<img width="712" alt="스크린샷 2025-04-04 오전 12 31 45" src="https://github.com/user-attachments/assets/2bd39b31-d3cc-4562-9b04-1b30da6fed55" />


## 👩‍💻 공유 포인트 및 논의 사항
 - 일반 로그인인 경우에는 바로 signin페이지로 이동하고, 카카오 로그인인 경우에는 이미지에 있는 곳으로 리다이렉트되고 로그아웃하면 signin페이지로 이동합니다.

## 멘토링 공유사항
 - 문제발생
 signin-callback폴더 안에 있는 page에서 kakaoSignIn(카카오 로그인 훅, toast로 로그인 성공 알림 표시)실행하게되는데 toast가 두번실행되는 것을 확인했습니다(useEffect가 두번실행). 카카오 인가코드는 일회용이기 때문에 처음  로그인을 성공해도 두번째 렌더링때 에러발생. => useEffect가 2번실행되는 것 자체가 문제.

 - 원인(추측)
 useSearchParams가 클라이언트 전용 훅이기때문에 SSR에서 먼저 null로 렌더링되고 hydration단계에서 값이 업데이트 되면서 리렌더링 발생. 이때 컴포넌트가 그려지면서 useEffect가 의도치않게 두번실행됨.

 - 해결(좋은 방법인지 모름)
 2개의 useEffect로 분리하여 카카오 인가코드를 받아오는 방법을 CSR일때 받아오게 설정.
 isProcessed상태값을 활용하여 kakaoSignIn이 한번만 실행되게 적용.


여기서 useEffect가 두번발생하는 원인이 useSearchParams를 사용해서 그런건지 궁금합니다. 구글링을했을때 이런 에러가 있다는 글은 못보고 GPT활용했을때 위의 원인을 알려주더라고요..
 
 
