### PR TITLE
feat(#313): 카카오 로그인시 콜백페이지에서 로딩기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-query-devtools": "^5.69.0",
         "axios": "^1.8.2",
         "dayjs": "^1.11.13",
-        "framer-motion": "^12.5.0",
+        "framer-motion": "^12.6.3",
         "js-cookie": "^3.0.5",
         "lightningcss": "^1.29.3",
         "lucide-react": "^0.479.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query-devtools": "^5.69.0",
     "axios": "^1.8.2",
     "dayjs": "^1.11.13",
-    "framer-motion": "^12.5.0",
+    "framer-motion": "^12.6.3",
     "js-cookie": "^3.0.5",
     "lightningcss": "^1.29.3",
     "lucide-react": "^0.479.0",

--- a/src/app/(auth)/oauth/kakao/components/LoadingSpinner.module.css
+++ b/src/app/(auth)/oauth/kakao/components/LoadingSpinner.module.css
@@ -1,0 +1,21 @@
+.container {
+  height: 100vh;
+  padding-top:20vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #f5f5f5;
+  border-top: 5px solid #0070f3;
+  border-radius: 50%;
+}
+
+.text {
+  margin-top: 20px;
+  font-size: 16px;
+  color: #333;
+}

--- a/src/app/(auth)/oauth/kakao/components/LoadingSpinner.tsx
+++ b/src/app/(auth)/oauth/kakao/components/LoadingSpinner.tsx
@@ -1,0 +1,24 @@
+import { motion } from 'framer-motion';
+import styles from './LoadingSpinner.module.css';
+
+export default function LoadingSpinner({
+  text = '로그인 처리 중입니다...',
+}: {
+  text?: string;
+}) {
+  return (
+    <div className={styles.container}>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.6 }}
+      />
+      <motion.div
+        className={styles.spinner}
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, duration: 1, ease: 'linear' }}
+      />
+      <p className={styles.text}>{text}</p>
+    </div>
+  );
+}

--- a/src/app/(auth)/oauth/kakao/signin-callback/page.tsx
+++ b/src/app/(auth)/oauth/kakao/signin-callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useKakaoSignInMutation } from '@/hooks/useAuth';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 export default function KakaoSignInCallbackPage() {
   const searchParams = useSearchParams();
@@ -31,9 +32,5 @@ export default function KakaoSignInCallbackPage() {
     kakaoSignIn.mutate(code);
   }, [code, router, kakaoSignIn, isProcessed]);
 
-  return (
-    <div style={{ textAlign: 'center', marginTop: '50px' }}>
-      <p>로그인 처리 중...</p>
-    </div>
-  );
+  return <LoadingSpinner text='카카오 로그인 처리중입니다...' />;
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #313 

## 📝 작업 내용
 - framer-motion 라이브러리를 사용해서 카카오 콜백 페이지에서 로그인 로딩을 구현했습니다.

## 📸 결과물

https://github.com/user-attachments/assets/a1045a06-9aaf-4d56-83cb-70f4bc948909


## 👩‍💻 공유 포인트 및 논의 사항
