### PR TITLE
fix(X): 예약 내역 페이지 - 무한스크롤로 데이터 패칭 후 페이지 이탈 시 데이터 내역 초기화 재업데이트

### DIFF
--- a/src/app/myreservation/page.tsx
+++ b/src/app/myreservation/page.tsx
@@ -8,15 +8,18 @@ import styles from './style.module.css';
 import PageController from './components/PageController';
 import { useStatusFilter } from '@/utils/useStatusFilter';
 import { useScrollDetector } from '@/utils/useScrollDetector';
-import { RefObject } from 'react';
+import { RefObject, useEffect } from 'react';
 import { useScrollPositioning } from '@/utils/useScrollPositioning';
 import ProfileCard from '@/components/ProfileCard/ProfileCard';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function MyReservation() {
   const { value, setValue, status, options } = useStatusFilter();
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useReservation(status);
+
+  const queryClient = useQueryClient();
 
   const reservationsData =
     data?.pages.flatMap((page) => page.reservations) ?? [];
@@ -38,6 +41,12 @@ export default function MyReservation() {
       fetchNextPage();
     }
   });
+
+  useEffect(() => {
+    return () => {
+      queryClient.removeQueries({ queryKey: ['reservation', status] });
+    };
+  }, [queryClient, status]);
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
## #️⃣ 이슈

- close #이슈번호X

## 📝 작업 내용
- 무한스크롤로 데이터 패칭 후 페이지 이탈 시 데이터 내역 초기화 작업 코드가 날아가 다시 업데이트 합니다.

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
